### PR TITLE
Fix admin query compat when the client SDK loads first

### DIFF
--- a/admin.ts
+++ b/admin.ts
@@ -4,6 +4,7 @@
  */
 
 import { FirestoreOrmRepository } from './repository';
+import { setupAdminSDKQueryCompatibility } from './query';
 
 // Admin SDK types using conditional import types
 type AdminApp = import('firebase-admin/app').App;
@@ -144,6 +145,13 @@ export async function initializeAdminApp(adminApp: AdminApp, key: string = Fires
         
         // Setup Admin SDK compatibility wrapper
         setupAdminSDKWrapper(connection as any, repository);
+
+        // Force admin-mode query functions. Without this, if the client SDK
+        // was importable when query.ts first loaded (common in fullstack
+        // bundles), the module-level query/where/orderBy stay locked on the
+        // client implementations and crash on Admin refs with e.g.
+        // `TypeError: <ref>._freezeSettings is not a function`.
+        setupAdminSDKQueryCompatibility();
         
         // Mark as ready immediately for Admin SDK
         (FirestoreOrmRepository as any).isReady = true;

--- a/query.ts
+++ b/query.ts
@@ -121,7 +121,13 @@ export function setupAdminSDKQueryCompatibility(): void {
         apply: (ref: any) => ref.where(field, op, value)
     })) as any;
     
-    collectionGroup = ((collectionId: string) => {
+    collectionGroup = ((...args: any[]) => {
+        // getFirestoreQuery calls this with the CLIENT SDK's two-arg
+        // signature collectionGroup(firestore, collectionId); accepting only
+        // (collectionId) passed a Firestore instance into
+        // firestore.collectionGroup(), crashing every admin collection-group
+        // query with `collectionId.indexOf is not a function`. Accept both.
+        const collectionId = typeof args[0] === 'string' ? args[0] : args[1];
         const connection = FirestoreOrmRepository.getGlobalConnection();
         const firestore = connection.getFirestore() as any;
         return firestore.collectionGroup(collectionId);

--- a/query.ts
+++ b/query.ts
@@ -39,9 +39,18 @@ function isAdminFirestore(firestore: any): boolean {
 }
 
 /**
- * Setup Admin SDK compatibility for query functions
+ * Setup Admin SDK compatibility for query functions.
+ *
+ * Exported (as an internal API) so the `admin` entry point can force admin
+ * mode from `initializeAdminApp`: `lazyLoadFirestoreImports()` below runs at
+ * module-load time, usually *before* any connection exists, and in
+ * environments where the client SDK is importable (e.g. a Next.js server
+ * bundle that also ships `firebase/firestore` for the browser) it locks the
+ * module-level `query`/`where`/`orderBy`/... onto the client implementations.
+ * Running those against Admin SDK refs later crashes with errors like
+ * `TypeError: <ref>._freezeSettings is not a function`.
  */
-function setupAdminSDKQueryCompatibility(): void {
+export function setupAdminSDKQueryCompatibility(): void {
     console.log("Setting up Admin SDK query compatibility");
     
     endAt = ((...values: any[]) => ({

--- a/test/scripts/admin.query.after-client-load.test.ts
+++ b/test/scripts/admin.query.after-client-load.test.ts
@@ -1,0 +1,43 @@
+import * as admin from 'firebase-admin';
+// Import the CLIENT SDK first, on purpose: this is the fullstack-bundle
+// scenario (e.g. a Next.js server build that also ships firebase for the
+// browser). query.ts's module-load lazyLoadFirestoreImports() finds no
+// connection, so it locks the module-level query helpers onto the client
+// implementations.
+import 'firebase/firestore';
+import { initializeAdminApp } from '../../admin';
+import { Product } from '../model/product';
+
+/**
+ * Regression test: initializeAdminApp must force admin-mode query functions
+ * even when the client SDK was importable/loaded first. Before the fix, the
+ * ORM built queries with the client SDK's query()/where() against Admin SDK
+ * refs, crashing with `TypeError: <ref>._freezeSettings is not a function`.
+ *
+ * Unlike admin.query.compatibility.test.ts (which tolerates generic errors),
+ * this test asserts the SHAPE of the built query: an Admin SDK Query exposes
+ * `.get()`, while a client Query does not.
+ */
+describe('Admin SDK query compatibility after client SDK load', () => {
+  it('builds Admin-SDK-shaped queries (with .get) after initializeAdminApp', async () => {
+    // No credential on purpose: building a query performs no I/O, and a
+    // credential-less app never hits the lazy ADC lookup — so this runs
+    // everywhere (CI included) instead of skipping like the mock-service-
+    // account variants do.
+    const adminApp = admin.initializeApp(
+      { projectId: 'test-project-id' },
+      `admin-after-client-${Date.now()}`,
+    );
+
+    await initializeAdminApp(adminApp);
+
+    // Building the query must not throw client-SDK internals errors...
+    const firestoreQuery = Product.query().where('name', '==', 'x').getFirestoreQuery() as any;
+    expect(firestoreQuery).toBeDefined();
+
+    // ...and must be an Admin SDK query: admin queries execute via `.get()`.
+    // (The client SDK's Query has no `.get` method — execution goes through
+    // the standalone getDocs() instead.)
+    expect(typeof firestoreQuery.get).toBe('function');
+  });
+});

--- a/test/scripts/admin.query.after-client-load.test.ts
+++ b/test/scripts/admin.query.after-client-load.test.ts
@@ -41,3 +41,16 @@ describe('Admin SDK query compatibility after client SDK load', () => {
     expect(typeof firestoreQuery.get).toBe('function');
   });
 });
+
+describe('Admin SDK collection-group queries after client SDK load', () => {
+  it('builds collection-group queries with the client two-arg collectionGroup signature', async () => {
+    // initializeAdminApp already ran in the sibling describe via the shared
+    // module state; building a CG query goes through the admin collectionGroup
+    // shim, which must tolerate getFirestoreQuery's client-SDK call shape
+    // collectionGroup(firestore, collectionId).
+    const { Member } = await import('../model/member');
+    const cgQuery = Member.collectionQuery().where('name', '==', 'x').getFirestoreQuery() as any;
+    expect(cgQuery).toBeDefined();
+    expect(typeof cgQuery.get).toBe('function');
+  });
+});


### PR DESCRIPTION
## Bug
In fullstack bundles (e.g. Next.js server builds that also ship `firebase/firestore` for the browser), `query.ts`'s `lazyLoadFirestoreImports()` runs at module-load time **before any connection exists**, falls into the no-connection catch, and locks the module-level `query`/`where`/`orderBy`/… onto the **client** SDK implementations. `initializeAdminApp` never re-installs the admin implementations, so every ORM query through an admin connection crashes:

```
TypeError: <ref>._freezeSettings is not a function
```

Found in production on Cloud Run (GrowthOS): any `Model.query().where(...).get()` via the admin entry point failed while plain `save()`/`load()` worked (those go through the `setupAdminSDKWrapper` repository overrides, which *are* installed).

## Fix
- `query.ts`: export `setupAdminSDKQueryCompatibility` (documented as internal).
- `admin.ts`: call it inside `initializeAdminApp`, right after `setupAdminSDKWrapper`.

## Regression test
`test/scripts/admin.query.after-client-load.test.ts` imports `firebase/firestore` **before** `initializeAdminApp` (reproducing the fullstack scenario) and asserts the built query is admin-shaped (`typeof query.get === 'function'`):
- without the fix: fails with the exact production error (`_freezeSettings is not a function`)
- with the fix: passes

Uses a credential-less admin app (query building does no I/O), so it actually runs in CI instead of skipping like the mock-service-account variants. Note `admin.query.compatibility.test.ts` didn't catch this because it tolerates any error other than `query is not a function`.

Pre-existing failures: 6 tests in the admin/client suites fail identically on unmodified `main` — unrelated to this change.

Downstream note: `smart-marketing` (GrowthOS) currently carries this fix as a `pnpm patch`; once this merges and publishes, the patch can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)